### PR TITLE
docs: 데이터 레포 거버넌스 컨벤션 및 운영 룰북 추가

### DIFF
--- a/docs/governance/CHANGELOG.md
+++ b/docs/governance/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Governance Changelog
+
+## 2026-02-18
+- `CONVENTIONS.md` 허브 추가
+- `CONVENTIONS_COMMON.md`/`CONVENTIONS_DATA.md` 분리
+- `DATA_OPERATION_RULEBOOK.md` 추가

--- a/docs/governance/CONVENTIONS.md
+++ b/docs/governance/CONVENTIONS.md
@@ -1,0 +1,15 @@
+# Conventions Hub
+
+이 문서는 `ahachul_data` 레포의 컨벤션 허브입니다.
+
+## Scopes
+
+- Common: `docs/governance/CONVENTIONS_COMMON.md`
+- Data Repo: `docs/governance/CONVENTIONS_DATA.md`
+- Backend Stack Reference: `/Users/createahb21/Documents/Programming/repositories/@Ahhachul/ahhachul_backend/docs/governance/CONVENTIONS_BE.md`
+
+## Precedence
+
+1. Repo-specific (`CONVENTIONS_DATA`)
+2. Shared (`CONVENTIONS_COMMON`)
+3. Operational rules (`DATA_OPERATION_RULEBOOK`)

--- a/docs/governance/CONVENTIONS_COMMON.md
+++ b/docs/governance/CONVENTIONS_COMMON.md
@@ -1,0 +1,17 @@
+# Common Conventions
+
+## Workflow
+
+- Task lifecycle: `Todo -> InProgress -> QAReady -> ValidatorPass -> Committed -> Done`
+- Failure path: `* -> Rework -> QAReady`
+- One task per commit.
+
+## Branch
+
+- Codex orchestration branch naming: `codex/<scope>`
+
+## Merge
+
+- 대형 구조 변경 PR: `Merge Commit` 우선
+- 소규모 문서/정리 PR: `Squash Merge`
+- 해시 추적 문서가 있으면 `Rebase Merge` 지양

--- a/docs/governance/CONVENTIONS_DATA.md
+++ b/docs/governance/CONVENTIONS_DATA.md
@@ -1,0 +1,24 @@
+# Data Repo Conventions (ahachul_data)
+
+## Commit Message
+
+- Existing repo style baseline: `feat:`, `fix:`, `docs:`, `refactor:`
+- 권장 형식: `<type>: <summary>`
+- 예시:
+  - `feat: 뉴스 크롤링 키워드 확장`
+  - `fix: redis stream 전송 예외 처리`
+  - `docs: 데이터 운영 가이드 업데이트`
+
+## Runtime/Config
+
+- 실행 진입점: `main.py`
+- 옵션 계약:
+  - `-o ca` (crawl all)
+  - `-o un` (update new)
+  - `-o ad -d YYYYMMDD` (after date)
+- 민감 설정은 `config.py` + 환경변수로 주입
+
+## Integration
+
+- 산출물(`datas/all.json`, `datas/subway_news_data.json`) 스키마 변경 시 backend/consumer 영향 검토 필수
+- Redis Stream key 변경 시 backend/consumer 동시 조정

--- a/docs/governance/DATA_OPERATION_RULEBOOK.md
+++ b/docs/governance/DATA_OPERATION_RULEBOOK.md
@@ -1,0 +1,21 @@
+# Data Operation Rulebook
+
+Last Updated: 2026-02-18
+
+## 1. 목적
+- 유실물/뉴스 데이터 수집과 전달(S3 + Redis Stream)의 안정 운영
+
+## 2. 필수 가드레일
+- 자격증명 하드코딩 금지
+- 운영 실행 전 대상 환경 변수 확인
+- 산출 스키마 변경 시 소비자(back-end, consumer) 영향 문서화
+
+## 3. 실행 체크
+- `python3 main.py -o ca`
+- `python3 main.py -o un`
+- `python3 main.py -o ad -d 20260101`
+- `python3 utils/news_crawling.py`
+
+## 4. 실패 시 중단 조건
+- Redis 연결 실패 상태로 데이터 적재를 강행하지 않는다.
+- S3 버킷/권한이 불확실한 상태에서 overwrite를 강행하지 않는다.


### PR DESCRIPTION
## 배경
`ahachul_data`는 크롤링/적재 레포 특성상 실행 옵션, 산출물 스키마, Redis/S3 연계 규칙이 운영 안정성에 직접 영향을 줍니다.
명시적 컨벤션과 운영 룰북이 필요해 문서화를 진행했습니다.

## 무엇을 변경했는가
- `docs/governance/` 디렉터리 신설
- 컨벤션 허브 + 공통/데이터 전용 컨벤션 분리
- 데이터 운영 룰북 및 변경 이력 문서 추가

## 주요 파일
- `docs/governance/CONVENTIONS.md`
- `docs/governance/CONVENTIONS_COMMON.md`
- `docs/governance/CONVENTIONS_DATA.md`
- `docs/governance/DATA_OPERATION_RULEBOOK.md`
- `docs/governance/CHANGELOG.md`

## 기대 효과
- 실행 옵션(`ca/un/ad`)과 산출물 계약을 팀 표준으로 고정
- 스키마 변경 시 backend/consumer 영향 검토가 절차화
- 레포별 커밋/브랜치 운영 규칙이 명확해짐

## 영향 범위
- 문서 추가/정리만 포함 (코드 로직 변경 없음)

## 체크리스트
- [x] 데이터 레포 기존 커밋 스타일(`feat/fix/docs/refactor`) 반영
- [x] 운영 중단 조건(Redis/S3 불확실 상태) 명문화
- [x] 상위 오케스트레이션 기준과 정합성 확보
